### PR TITLE
use more consistent padding for PoliciesPanel

### DIFF
--- a/packages/webapp/src/components/panels/PoliciesPanel.tsx
+++ b/packages/webapp/src/components/panels/PoliciesPanel.tsx
@@ -33,7 +33,7 @@ const POLICIES: Array<Policy> = [
 export function PoliciesPanel(props: {
     gameState: GameState
 }) {
-    return <div style={{backgroundColor: getShade(1), display: "flex", flexDirection: "column", padding: 10, gap: 10}}>
+    return <div style={{backgroundColor: getShade(1), padding: 20}}>
         <Details details={POLICIES.map(policy => ({
             name: policy.name,
             backgroundColor: getColor(policy.hue, 0),


### PR DESCRIPTION
this is a little tweak to make it so the total padding for the details items in the policies panel are the same as the gap between those items. I also get rid of the flexbox style properties since it doesnt need it


See it at https://democracymanifest.paulapps.dev/