### PR TITLE
add voting bag and marketplace panels

### DIFF
--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -10,6 +10,7 @@ import { PlayerClassPanel } from "./panels/PlayerClassPanel"
 import { AllPlayerClassesPanel } from "./panels/AllPlayerClassesPanel"
 import { PoliciesPanel } from "./panels/PoliciesPanel"
 import { VotingBagPanel } from "./panels/VotingBagPanel"
+import { MarketplacePanel } from "./panels/MarketplacePanel"
 
 interface Props {
 	config: DynamicWebappConfig,
@@ -95,6 +96,8 @@ export function App(props: Props) {
 							return <PoliciesPanel gameState={gameState}/>
 						} else if (selectedTab.current === "Voting Bag") {
 							return <VotingBagPanel gameState={gameState}/>
+						} else if (selectedTab.current === "Marketplace") {
+							return <MarketplacePanel gameState={gameState}/>
 						}
 					})()
 				}

--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -9,6 +9,7 @@ import { getPlayerColor, getShade } from "../utilities/Color"
 import { PlayerClassPanel } from "./panels/PlayerClassPanel"
 import { AllPlayerClassesPanel } from "./panels/AllPlayerClassesPanel"
 import { PoliciesPanel } from "./panels/PoliciesPanel"
+import { VotingBagPanel } from "./panels/VotingBagPanel"
 
 interface Props {
 	config: DynamicWebappConfig,
@@ -92,6 +93,8 @@ export function App(props: Props) {
 							return <PlayerClassPanel playerClass={getPlayerClass(selectedTab.current as PlayerClassName)} gameState={gameState} zoomed={true} onClickZoom={() => selectedTab.current = "All classes"}/>
 						} else if (selectedTab.current === "Policies") {
 							return <PoliciesPanel gameState={gameState}/>
+						} else if (selectedTab.current === "Voting Bag") {
+							return <VotingBagPanel gameState={gameState}/>
 						}
 					})()
 				}

--- a/packages/webapp/src/components/Icon.tsx
+++ b/packages/webapp/src/components/Icon.tsx
@@ -1,13 +1,14 @@
+import { MATERIAL_ICON_NAME_MAPPINGS } from "../utilities/Constants";
 import { IndustryName } from "../utilities/Types";
 
 export function Icon(props: {
-    name: IndustryName | "tax-multiplier"
+    name: IndustryName | (keyof typeof MATERIAL_ICON_NAME_MAPPINGS)
     size?: number,
     gap?: number
 }) {
 	const effectiveSize: number = props.size ?? 24
-    if (props.name === "tax-multiplier") {
-        return <span className="material-symbols-outlined" style={{paddingLeft: props.gap, paddingRight: props.gap, fontVariationSettings: "'FILL' 1"}}>receipt_long</span>
+    if (Object.keys(MATERIAL_ICON_NAME_MAPPINGS).includes(props.name)) {
+        return <span className="material-symbols-outlined" style={{fontSize: effectiveSize, paddingLeft: props.gap, paddingRight: props.gap, fontVariationSettings: "'FILL' 1"}}>{(MATERIAL_ICON_NAME_MAPPINGS as any)[props.name]}</span>
     } else {
         return <img className="white-out" src={`icons/${props.name}.svg`} style={{width: effectiveSize, height: effectiveSize, paddingLeft: props.gap, paddingRight: props.gap}}/>
     }

--- a/packages/webapp/src/components/panels/MarketplacePanel.tsx
+++ b/packages/webapp/src/components/panels/MarketplacePanel.tsx
@@ -1,0 +1,86 @@
+import { groupBy } from "lodash"
+import { getColor, getShade } from "../../utilities/Color"
+import { EXPORT_DEALS, IMPORT_DEALS, INDUSTRIES } from "../../utilities/Constants"
+import { getImportPrice, getIndustry, getPlayerClass } from "../../utilities/Game"
+import { GameState, IndustryName } from "../../utilities/Types"
+import { Details } from "../Details"
+import { Icon } from "../Icon"
+
+export function MarketplacePanel(props: {
+	gameState: GameState
+}) {
+	return <div style={{backgroundColor: getShade(1), padding: 10}}>
+		<Details details={[
+			...INDUSTRIES.map(industry => ({
+				name: `${industry.name} for sale`,
+				content: <table style={{backgroundColor: getColor(industry.hue, 0), borderRadius: 4}}>
+					<tr>
+						<th style={{textAlign: "left"}}>Seller</th>
+						<th style={{textAlign: "right"}}>Unit Price</th>
+						<th style={{textAlign: "right"}}>Quantity</th>
+					</tr>
+					{
+						(() => {
+							const rows = [
+								...["Middle Class", "Capitalist Class", "State"].map(playerClassName => {
+									const playerClassState = props.gameState.classes.find(clazz => clazz.className === playerClassName)!
+									if (playerClassState.storedGoods[industry.name].price > 0) {
+										return <tr>
+											<td style={{textAlign: "left"}}>{playerClassName}</td>
+											<td style={{textAlign: "right"}}>${playerClassState.storedGoods[industry.name].price}</td>
+											<td style={{textAlign: "right"}}>{playerClassState.storedGoods[industry.name].quantity}</td>
+										</tr>
+									} else {
+										return undefined
+									}
+								}),
+								industry.name === "Food" || industry.name === "Luxury" ? (
+									<tr>
+										<td style={{textAlign: "left"}}>Foreign Market</td>
+										<td style={{textAlign: "right"}}>${getImportPrice(industry.name, props.gameState.policies["Foreign Trade"].state)}</td>
+										<td style={{textAlign: "right", paddingTop: 0, paddingBottom: 0}}><Icon name="infinity"/></td>
+									</tr>
+								) : (
+									undefined
+								)
+							].filter(x => x !== undefined)
+							if (rows.length === 0) {
+								rows.push(
+									<tr style={{textAlign: "center"}}>
+										<td style={{textAlign: "left"}}>-</td>
+										<td style={{textAlign: "right"}}>-</td>
+										<td style={{textAlign: "right"}}>-</td>
+									</tr>
+								)
+							}
+							return rows
+						})()
+					}
+				</table>
+			})),
+			{name: "Import deals", content:
+				<div style={{display: "flex", flexDirection: "column", gap: 10}}>
+					{
+						props.gameState.importDeals.map(i => IMPORT_DEALS[i]).map(importDeal => <span style={{display: "flex", alignItems: "center", gap: 3}}>
+							Capitalist may purchase <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Food").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.foodQuantity} <Icon name="Food" gap={3}/></span> + <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Luxury").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.luxuryQuantity} <Icon name="Luxury" gap={3}/></span> for ${importDeal.cost[props.gameState.policies["Foreign Trade"].state]}
+						</span>)
+					}
+				</div>
+			},
+			{name: "Export deals", content:
+				<div style={{display: "flex", gap: 10}}>
+					{
+						Object.entries(groupBy(EXPORT_DEALS[props.gameState.exportDeals], x => x.industry))
+							.map(exportDealGroup => <div style={{display: "flex", flexDirection: "column", gap: 10}}>
+								{
+									exportDealGroup[1].map(exportDeal => <span style={{display: "flex", alignItems: "center", padding: 10, backgroundColor: getColor(getIndustry(exportDealGroup[0] as IndustryName).hue, 0), borderRadius: 4}}>
+										{exportDeal.quantity} <Icon name={exportDeal.industry} gap={3}/> <Icon name={"produces"} gap={3}/> ${exportDeal.award}
+									</span>)
+								}
+							</div>)
+					}
+				</div>
+			}
+		]}/>
+	</div>
+}

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -1,7 +1,7 @@
 import { range } from "lodash"
 import { getColor, getPlayerColor } from "../../utilities/Color"
 import { CapitalistClassState, GameState, PlayerClass, PlayerClassName, StateClassState, Worker, WorkingClassState } from "../../utilities/Types"
-import { COMPANY_SIZE_PX, INDUSTRIES, WEALTH_TIER_THRESHOLDS } from "../../utilities/Constants"
+import { COMPANY_SIZE_PX, INDUSTRIES, MAX_CREDIBILITY_PER_CLASS, WEALTH_TIER_THRESHOLDS } from "../../utilities/Constants"
 import { CompanyCard } from "../CompanyCard"
 import { capitalToWealthTier, getMaxStorage } from "../../utilities/Game"
 import { RadioSelector } from "../RadioSelector"
@@ -130,9 +130,9 @@ export function PlayerClassPanel(props: Props) {
 				<div style={{display: "flex", flexDirection: "column", gap: 5}}>
 					{
 						Object.entries((classState as StateClassState).credibility).map(credEntry => <div style={{display: "flex", justifyContent: "space-between", gap: 100, backgroundColor: getPlayerColor(credEntry[0] as PlayerClassName, 1), borderRadius: 4, overflow: "hidden", position: "relative"}}>
-							<div style={{position: "absolute", top: 0, left: 0, height: "100%", width: `${100 * (credEntry[1]/10)}%`, backgroundColor: getPlayerColor(credEntry[0] as PlayerClassName, 0)}}/>
+							<div style={{position: "absolute", top: 0, left: 0, height: "100%", width: `${100 * (credEntry[1]/MAX_CREDIBILITY_PER_CLASS)}%`, backgroundColor: getPlayerColor(credEntry[0] as PlayerClassName, 0)}}/>
 							<span style={{zIndex: 1, padding: 10}}>{credEntry[0]}:</span>
-							<span style={{zIndex: 1, padding: 10}}>{credEntry[1]}/10</span>
+							<span style={{zIndex: 1, padding: 10}}>{credEntry[1]}/{MAX_CREDIBILITY_PER_CLASS}</span>
 						</div>)
 					}
 				</div>

--- a/packages/webapp/src/components/panels/PoliciesPanel.tsx
+++ b/packages/webapp/src/components/panels/PoliciesPanel.tsx
@@ -1,5 +1,5 @@
 import { getColor, getPlayerColor, getShade } from "../../utilities/Color"
-import { getIndustry } from "../../utilities/Game"
+import { getImportPrice, getIndustry } from "../../utilities/Game"
 import { isAre, s } from "../../utilities/Misc"
 import { GameState, PolicyName } from "../../utilities/Types"
 import { Details } from "../Details"
@@ -25,7 +25,7 @@ const POLICIES: Array<Policy> = [
         +{2-level} <Icon name="tax-multiplier" gap={3}/>, and public <Icon name="Education" gap={3}/> costs ${level * 5}
     </span>)},
 	{name: "Foreign Trade", hue: 90, content: [0, 1, 2].map(level => <span style={{display: "flex", alignItems: "center"}}>
-        Imports of <Icon name="Food" gap={3}/> cost ${10 + 5*(2-level)}, imports of <Icon name="Luxury" gap={3}/> cost ${6 + 3*(2-level)}, and {level} trade deal{s(level)} {isAre(level)} drawn
+        Imports of <Icon name="Food" gap={3}/> cost ${getImportPrice("Food", level)}, imports of <Icon name="Luxury" gap={3}/> cost ${getImportPrice("Luxury", level)}, and {level} trade deal{s(level)} {isAre(level)} drawn
     </span>)},
 	{name: "Immigration", hue: 135, content: [0, 1, 2].map(level => `+${level} middle class and working class workers per round`)}
 ]

--- a/packages/webapp/src/components/panels/PoliciesPanel.tsx
+++ b/packages/webapp/src/components/panels/PoliciesPanel.tsx
@@ -1,4 +1,4 @@
-import { getColor, getShade } from "../../utilities/Color"
+import { getColor, getPlayerColor, getShade } from "../../utilities/Color"
 import { getIndustry } from "../../utilities/Game"
 import { isAre, s } from "../../utilities/Misc"
 import { GameState, PolicyName } from "../../utilities/Types"
@@ -15,7 +15,7 @@ type Policy = {
 const POLICIES: Array<Policy> = [
 	{name: "Fiscal Policy", hue: 210, content: [0, 1, 2].map(level => `State may have ${3*(3-level)} companies, but ${level === 2 ? "one" : "two"} unpaid loan${level === 2 ? "" : "s"} triggers IMF`)},
 	{name: "Labor Market", hue: 260, content: ["High minimum wage", "Medium minimum wage", "Low minimum wage"]},
-	{name: "Taxation", hue: 305, content: [0, 1, 2].map(level => <span style={{display: "flex", alignItems: "center"}}>
+	{name: "Taxation", hue: 280, content: [0, 1, 2].map(level => <span style={{display: "flex", alignItems: "center"}}>
         +{3-level} <Icon name="tax-multiplier" gap={3}/>, and the Healthcare and Education policies' <Icon name="tax-multiplier" gap={3}/> are {2-level}x
     </span>)},
 	{name: "Healthcare", hue: getIndustry("Healthcare").hue, content: [0, 1, 2].map(level => <span style={{display: "flex", alignItems: "center"}}>
@@ -38,13 +38,22 @@ export function PoliciesPanel(props: {
             name: policy.name,
             backgroundColor: getColor(policy.hue, 0),
             content: <RadioSelector choices={policy.content.map((content, index) => ({
-                content: <div style={{display: "flex", alignItems: "center", gap: 5}}>
+                content: <div style={{display: "flex", alignItems: "center", gap: 5, flexWrap: "wrap"}}>
                     <span>{String.fromCharCode(65 + index)}</span>
                     <span>|</span>
                     {content}
+                    {
+                        (props.gameState.policies[policy.name].proposal?.proposedState === index) ? (
+                            <div style={{backgroundColor: getPlayerColor(props.gameState.policies[policy.name].proposal!.playerClassName, 0), borderRadius: "50%", height: 20, width: 20, borderStyle: "solid", borderWidth: 2, display: "flex", justifyContent: "center", alignItems: "center"}}>
+                                <Icon name="vote" size={16}/>
+                            </div>
+                        ) : (
+                            undefined
+                        )
+                    }
                 </div>,
                 value: index
-            }))} value={props.gameState.policies[policy.name]} onChange={() => undefined} active={false}/>
+            }))} value={props.gameState.policies[policy.name].state} onChange={() => undefined} active={false}/>
         }))}/>
     </div>
 }

--- a/packages/webapp/src/components/panels/VotingBagPanel.tsx
+++ b/packages/webapp/src/components/panels/VotingBagPanel.tsx
@@ -1,0 +1,17 @@
+import { getPlayerColor, getShade } from "../../utilities/Color"
+import { TOTAL_NUM_VOTING_CUBES_PER_CLASS } from "../../utilities/Constants"
+import { GameState, PlayerClassName } from "../../utilities/Types"
+
+export function VotingBagPanel(props: {
+    gameState: GameState
+}) {
+	return <div style={{display: "flex", flexDirection: "column", padding: 20, gap: 20, backgroundColor: getShade(1)}}>
+		{
+			Object.entries(props.gameState.votingBag).map(entry => <div style={{display: "flex", justifyContent: "space-between", gap: 100, backgroundColor: getPlayerColor(entry[0] as PlayerClassName, 1), borderRadius: 4, overflow: "hidden", position: "relative"}}>
+				<div style={{position: "absolute", top: 0, left: 0, height: "100%", width: `${100 * (entry[1]/TOTAL_NUM_VOTING_CUBES_PER_CLASS)}%`, backgroundColor: getPlayerColor(entry[0] as PlayerClassName, 0)}}/>
+				<span style={{zIndex: 1, padding: 10}}>{entry[0]}:</span>
+				<span style={{zIndex: 1, padding: 10}}>{entry[1]}/{TOTAL_NUM_VOTING_CUBES_PER_CLASS}</span>
+			</div>)
+		}
+	</div>
+}

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -11,5 +11,24 @@ body {
 }
 
 img.white-out {
-  filter: brightness(0) invert(1);
+	filter: brightness(0) invert(1);
+}
+
+
+table {
+	border-collapse: collapse;
+	width: 100%;
+}
+
+td, th {
+	padding: 10px;
+}
+
+th {
+	border-bottom: 2px solid white;
+}
+
+tr:nth-child(even) {
+	background-color: rgba(0, 0, 0, 0.06);
+	background-blend-mode: multiply;
 }

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -9,6 +9,11 @@ export const BACKGROUND_SHADE_T1 = "#2b3438"
 export const ACCENT_COLOR_SATURATION = 25
 export const ACCENT_COLOR_LIGHTNESS = 45
 
+export const MATERIAL_ICON_NAME_MAPPINGS = {
+	"tax-multiplier": "receipt_long",
+	"vote": "gavel"
+}
+
 export const INDUSTRIES: Array<Industry> = [
 	{name: "Food", hue: 120},
 	{name: "Luxury", hue: 210},
@@ -166,13 +171,35 @@ export const COMPANY_TYPES: Array<CompanyType> = [
 
 export const GAME_STATE: GameState = {
 	policies: {
-		"Fiscal Policy": 0,
-		"Labor Market":  1,
-		"Taxation": 1,
-		"Healthcare": 2,
-		"Education": 2,
-		"Foreign Trade": 2,
-		"Immigration": 0
+		"Fiscal Policy": {
+			state: 0,
+			proposal: {
+				playerClassName: "Capitalist Class",
+				proposedState: 1
+			}
+		},
+		"Labor Market": {
+			state: 0
+		},
+		"Taxation": {
+			state: 1,
+			proposal: {
+				playerClassName: "Working Class",
+				proposedState: 2
+			}
+		},
+		"Healthcare": {
+			state: 2
+		},
+		"Education": {
+			state: 2
+		},
+		"Foreign Trade": {
+			state: 2
+		},
+		"Immigration": {
+			state: 2
+		}
 	},
 	classes: [
 		{

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -14,6 +14,9 @@ export const MATERIAL_ICON_NAME_MAPPINGS = {
 	"vote": "gavel"
 }
 
+export const MAX_CREDIBILITY_PER_CLASS = 10
+export const TOTAL_NUM_VOTING_CUBES_PER_CLASS = 25
+
 export const INDUSTRIES: Array<Industry> = [
 	{name: "Food", hue: 120},
 	{name: "Luxury", hue: 210},
@@ -200,6 +203,11 @@ export const GAME_STATE: GameState = {
 		"Immigration": {
 			state: 2
 		}
+	},
+	votingBag: {
+		"Working Class": 7,
+		"Middle Class": 8,
+		"Capitalist Class": 3
 	},
 	classes: [
 		{

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -1,4 +1,4 @@
-import { CompanyType, GameState, Industry, PlayerClass } from "./Types"
+import { CompanyType, ExportDeals, GameState, ImportDeal, Industry, PlayerClass } from "./Types"
 
 export const COMPANY_SIZE_PX = 220
 
@@ -11,7 +11,9 @@ export const ACCENT_COLOR_LIGHTNESS = 45
 
 export const MATERIAL_ICON_NAME_MAPPINGS = {
 	"tax-multiplier": "receipt_long",
-	"vote": "gavel"
+	"vote": "gavel",
+	"infinity": "all_inclusive",
+	"produces": "arrow_right_alt"
 }
 
 export const MAX_CREDIBILITY_PER_CLASS = 10
@@ -108,6 +110,40 @@ export const PLAYER_CLASSES: Array<PlayerClass> = [
 			Influence: [10]
 		}
 	}
+]
+
+export const IMPORT_DEALS: Array<ImportDeal> = [
+	{
+		foodQuantity: 7,
+		luxuryQuantity: 5,
+		cost: {
+			0: 84,
+			1: 82,
+			2: 70
+		}
+	},
+	{
+		foodQuantity: 0,
+		luxuryQuantity: 8,
+		cost: {
+			0: 46,
+			1: 38,
+			2: 30
+		}
+	}
+]
+
+export const EXPORT_DEALS: Array<ExportDeals> = [
+	[
+		{quantity: 3, industry: "Food", award: 25},
+		{quantity: 6, industry: "Food", award: 50},
+		{quantity: 3, industry: "Luxury", award: 20},
+		{quantity: 7, industry: "Luxury", award: 50},
+		{quantity: 3, industry: "Healthcare", award: 20},
+		{quantity: 7, industry: "Healthcare", award: 40},
+		{quantity: 2, industry: "Education", award: 15},
+		{quantity: 7, industry: "Education", award: 55}
+	]
 ]
 
 export const COMPANY_TYPES: Array<CompanyType> = [
@@ -209,6 +245,8 @@ export const GAME_STATE: GameState = {
 		"Middle Class": 8,
 		"Capitalist Class": 3
 	},
+	importDeals: [0, 1],
+	exportDeals: 0,
 	classes: [
 		{
 			className: "Working Class",

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -1,5 +1,5 @@
 import { INDUSTRIES, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
-import { CapitalistClassState, ClassState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
+import { CapitalistClassState, ClassState, GameState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
 
 export function getIndustry(industryName: IndustryName): Industry {
 	return INDUSTRIES.find(industry => industry.name === industryName)!
@@ -22,4 +22,12 @@ export function capitalToWealthTier(capital: number): number {
 		if (capital > WEALTH_TIER_THRESHOLDS[i]) return i
 	}
 	return 0
+}
+
+export function getImportPrice(industryName: "Food" | "Luxury", level: number): number {
+	if (industryName === "Food") {
+		return 10 + 5*(2-level)
+	} else {
+		return 6 + 3*(2-level)
+	}
 }

--- a/packages/webapp/src/utilities/Types.ts
+++ b/packages/webapp/src/utilities/Types.ts
@@ -114,6 +114,22 @@ export type StateClassState = CommonClassState & {
 	}
 }
 
+export type ImportDeal = {
+	foodQuantity: number,
+	luxuryQuantity: number,
+	cost: {
+		0: number,
+		1: number,
+		2: number
+	}
+}
+
+export type ExportDeals = Array<{
+	industry: IndustryName,
+	quantity: number,
+	award: number
+}>
+
 export type GameState = {
 	policies: {
 		[K in PolicyName]: {
@@ -128,7 +144,9 @@ export type GameState = {
 		"Working Class": number,
 		"Middle Class": number,
 		"Capitalist Class": number
-	}
+	},
+	importDeals: Array<number>,
+	exportDeals: number,
 	classes: [WorkingClassState, MiddleClassState, CapitalistClassState, StateClassState],
 	unemployedWorkers: Array<Worker>
 }

--- a/packages/webapp/src/utilities/Types.ts
+++ b/packages/webapp/src/utilities/Types.ts
@@ -116,8 +116,14 @@ export type StateClassState = CommonClassState & {
 
 export type GameState = {
 	policies: {
-		[K in PolicyName]: 0 | 1 | 2
-	}
+		[K in PolicyName]: {
+			state: 0 | 1 | 2,
+			proposal?: {
+				playerClassName: PlayerClassName,
+				proposedState: 0 | 1 | 2
+			}
+		}
+	},
 	classes: [WorkingClassState, MiddleClassState, CapitalistClassState, StateClassState],
 	unemployedWorkers: Array<Worker>
 }

--- a/packages/webapp/src/utilities/Types.ts
+++ b/packages/webapp/src/utilities/Types.ts
@@ -124,6 +124,11 @@ export type GameState = {
 			}
 		}
 	},
+	votingBag: {
+		"Working Class": number,
+		"Middle Class": number,
+		"Capitalist Class": number
+	}
 	classes: [WorkingClassState, MiddleClassState, CapitalistClassState, StateClassState],
 	unemployedWorkers: Array<Worker>
 }

--- a/packages/webapp/src/utilities/Zod.ts
+++ b/packages/webapp/src/utilities/Zod.ts
@@ -2,4 +2,4 @@ import { z } from "zod"
 
 export const playerClassNameZod = z.enum(["Working Class", "Middle Class", "Capitalist Class", "State"])
 
-export const tabNameZod = z.enum(["All classes", ...playerClassNameZod.options, "Policies"])
+export const tabNameZod = z.enum(["All classes", ...playerClassNameZod.options, "Policies", "Voting Bag"])

--- a/packages/webapp/src/utilities/Zod.ts
+++ b/packages/webapp/src/utilities/Zod.ts
@@ -2,4 +2,4 @@ import { z } from "zod"
 
 export const playerClassNameZod = z.enum(["Working Class", "Middle Class", "Capitalist Class", "State"])
 
-export const tabNameZod = z.enum(["All classes", ...playerClassNameZod.options, "Policies", "Voting Bag"])
+export const tabNameZod = z.enum(["All classes", ...playerClassNameZod.options, "Policies", "Voting Bag", "Marketplace"])


### PR DESCRIPTION
* Add visual representation of what votes are proposed, also add that to the GameState
* Add voting bag panel
  * It just tells you how many voting units from each of the non-state classes are in the bag
  * As a part of this I add that information to the GameState
  * The planning doc didn't have much detail and I'm not sure what else we'd really put in this panel
* Add marketplace panel. It has three main things:
  * All the resources for sale, per industry
     * I put some of the main table styling in the css file since it was easier and I figured we will probably have similar styling for other tables. if that turns out to not be the case we can always specify it in the MarketplacePanel.jsx instead
     * As of now the tables can't be set to sort by column. I think that will probably be a nice to have which we would probably want to add a lot later as a part of a generic Table component
  * The import deals for the capitalist
    * The GameState added for this is a list of indexes to a constant IMPORT_DEALS array. that's because the import deals are based on a random selection from a let list of possible deals
  * The export deals for the middle class, capitalist, or state to sell to the foreign market
    * The GameState added for this is an index to a constant EXPORT_DEALS 2D array. that's because the export deals are based on a random selection from a set list of possible lists of deals
  
See it at https://democracymanifest.paulapps.dev/