### PR TITLE
Add end-of-round company production

### DIFF
--- a/packages/webapp/src/components/CompanyCard.tsx
+++ b/packages/webapp/src/components/CompanyCard.tsx
@@ -1,17 +1,18 @@
 import { sum } from "lodash"
 import { getColor } from "../utilities/Color"
-import { COMPANY_SIZE_PX, COMPANY_TYPES, INDUSTRIES } from "../utilities/Constants"
+import { COMPANY_SIZE_PX, INDUSTRIES } from "../utilities/Constants"
 import { Company, WorkerClass } from "../utilities/Types"
 import { RadioSelector } from "./RadioSelector"
 import { WorkerView } from "./WorkerView"
 import { Icon } from "./Icon"
+import { getCompanyType } from "../utilities/Game"
 
 interface Props {
 	company: Company
 }
 
 export function CompanyCard(props: Props) {
-	const companyType = COMPANY_TYPES.find(companyType => companyType.name === props.company.name)!
+	const companyType = getCompanyType(props.company)
 	const industry = INDUSTRIES.find(industry => industry.name === companyType.industry)!
 	const mainWorkerSlots = companyType.workerSlots.filter(workerSlot => workerSlot.productionBonus === undefined)
 	const bonusWorkerSlots = companyType.workerSlots.filter(workerSlot => workerSlot.productionBonus !== undefined)

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -1,7 +1,7 @@
 import { range } from "lodash"
 import { getColor, getPlayerColor } from "../../utilities/Color"
 import { CapitalistClassState, GameState, IndustryName, PlayerClass, PlayerClassName, StateClassState, Worker, WorkingClassState } from "../../utilities/Types"
-import { COMPANY_SIZE_PX, INDUSTRIES, MAX_CREDIBILITY_PER_CLASS, WEALTH_TIER_THRESHOLDS, WORKER_SIZE_PX } from "../../utilities/Constants"
+import { COMPANY_SIZE_PX, INDUSTRIES, MAX_CREDIBILITY_PER_CLASS, MAX_EXPORT_ONLY_GOODS, WEALTH_TIER_THRESHOLDS, WORKER_SIZE_PX } from "../../utilities/Constants"
 import { CompanyCard } from "../CompanyCard"
 import { capitalToWealthTier, getIndustry, getMaxStorage, getTurn } from "../../utilities/Game"
 import { RadioSelector } from "../RadioSelector"
@@ -60,14 +60,13 @@ export function PlayerClassPanel(props: Props) {
 			) : (
 				undefined
 			)},
-			{name: "Export-only goods", content: (classState as CapitalistClassState).exportOnlyGoods !== undefined && Object.values((classState as CapitalistClassState).exportOnlyGoods).some(q => q > 0) ? (
+			{name: "Export-only goods", content: (classState as CapitalistClassState).exportOnlyGoods !== undefined ? (
 				<div style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
 					{
 						(Object.entries((classState as CapitalistClassState).exportOnlyGoods) as Array<[IndustryName, number]>)
-							.filter(([_, quantity]) => quantity > 0)
-							.map(([industryName, quantity]) => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(getIndustry(industryName).hue, 0), padding: 10, gap: 10, borderRadius: 4}}>
+							.map(([industryName, quantity]) => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(getIndustry(industryName).hue, 0), padding: 10, gap: 10, borderRadius: 4, width: 40}}>
 								<Icon name={industryName as any}/>
-								<span>{quantity}</span>
+								<span>{quantity}/{MAX_EXPORT_ONLY_GOODS[industryName as keyof CapitalistClassState["exportOnlyGoods"]]}</span>
 							</div>)
 					}
 				</div>

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -89,7 +89,7 @@ export function PlayerClassPanel(props: Props) {
 			{name: "Unemployed workers", content: unemployedWorkers.length > 0 ? (
 				<div style={{display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 10}}>
 					{
-						unemployedWorkers.map(worker => <div style={{width: WORKER_SIZE_PX, height: WORKER_SIZE_PX, display: "flex", justifyContent: "center", alignItems: "center"}}><WorkerView key={JSON.stringify(worker)} worker={worker}/></div>)
+						unemployedWorkers.map(worker => <div style={{width: WORKER_SIZE_PX, height: WORKER_SIZE_PX, display: "flex", justifyContent: "center", alignItems: "center"}}><WorkerView worker={worker}/></div>)
 					}
 				</div>
 			) : (

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -41,12 +41,12 @@ export function PlayerClassPanel(props: Props) {
 			{name: "Loans", content: classState.loans > 0 ? classState.loans : undefined},
 			{name: "Number of workers", content: numberOfWorkers},
 			{name: "Population level", content: populationLevel},
-			{name: "Stored goods", content: INDUSTRIES.filter(industry => getMaxStorage(classState, industry) > 0).length > 0 ? (
+			{name: "Stored goods", content: INDUSTRIES.filter(industry => getMaxStorage(classState, industry.name) > 0).length > 0 ? (
 				<div style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
 					{
-						INDUSTRIES.filter(industry => getMaxStorage(classState, industry) > 0).map(industry => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(industry.hue, 0), padding: 10, gap: 10, borderRadius: 4}}>
+						INDUSTRIES.filter(industry => getMaxStorage(classState, industry.name) > 0).map(industry => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(industry.hue, 0), padding: 10, gap: 10, borderRadius: 4}}>
 							<Icon name={industry.name}/>
-							<span>{classState.storedGoods[industry.name].quantity}/{getMaxStorage(classState, industry)}</span>
+							<span>{classState.storedGoods[industry.name].quantity}/{getMaxStorage(classState, industry.name)}</span>
 							<RadioSelector
 								choices={props.playerClass.storagePriceOptions[industry.name].map(price => ({value: price, content: `$${price}`})).reverse()}
 								onChange={() => undefined}

--- a/packages/webapp/src/hooks/useGameState.ts
+++ b/packages/webapp/src/hooks/useGameState.ts
@@ -2,7 +2,7 @@ import { clone, shuffle, sum } from "lodash"
 import { ImmutableRefObject } from "../classes/ImmutableRefObject"
 import { GameState, PolicyName } from "../utilities/Types"
 import { useRefState } from "./useRefState"
-import { getTurn } from "../utilities/Game"
+import { getTurn, isCompanyOperational, produceForCompany } from "../utilities/Game"
 import { NUM_POLITICAL_PRESSURE_PER_VOTE, PLAYER_CLASSES } from "../utilities/Constants"
 
 // The internals will be replaced with complicated network state management stuff later
@@ -52,6 +52,17 @@ export function useGameState(originalGameState: GameState, options?: {sideEffect
 
 				// Check for ending the round
 				if (Object.entries(gameState.current.policies).find(policy => policy[1].proposal !== undefined) === undefined) {
+
+					// Production
+					gameState.current.classes.forEach(classState => {
+						classState.companies.forEach(company => {
+							if (isCompanyOperational(company)) {
+								produceForCompany(gameState.current, classState, company)
+							}
+							company.workers.forEach(worker => worker.committed = false)
+						})
+					})
+
 					gameState.current.turnIndex += 1
 					gameState.current.mainActionCompleted = false
 					gameState.current.freeActionCompleted = false

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -369,10 +369,6 @@ export const GAME_STATE: GameState = {
 		},
 		"Taxation": {
 			state: 1,
-			proposal: {
-				playerClassName: "Working Class",
-				proposedState: 2
-			}
 		},
 		"Healthcare": {
 			state: 2

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -37,6 +37,10 @@ export const NUM_POLITICAL_PRESSURE_PER_VOTE = 5
 
 export const BASE_FOOD_IMPORT_PRICE = 10
 export const BASE_LUXURY_IMPORT_PRICE = 6
+export const MAX_EXPORT_ONLY_GOODS = {
+	"Food": 8,
+	"Luxury": 12
+}
 
 export const INDUSTRIES: Array<Industry> = [
 	{name: "Food", hue: 120},
@@ -460,7 +464,7 @@ export const GAME_STATE: GameState = {
 			drawnActions: take(DRAWN_ACTIONS.filter(x => x.playerClasses.includes("Capitalist Class")), 4).map(x => DRAWN_ACTIONS.indexOf(x)),
 			storedGoods: {
 				Food: {quantity: 2, price: 12},
-				Luxury: {quantity: 25, price: 8},
+				Luxury: {quantity: 33, price: 8},
 				Healthcare: {quantity: 0, price: 8},
 				Education: {quantity: 0, price: 8},
 				Influence: {quantity: 0, price: 0}

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -1,8 +1,13 @@
-import { BASE_FOOD_IMPORT_PRICE, BASE_LUXURY_IMPORT_PRICE, INDUSTRIES, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
-import { CapitalistClassState, ClassState, GameState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName } from "./Types"
+import _, { sum } from "lodash"
+import { BASE_FOOD_IMPORT_PRICE, BASE_LUXURY_IMPORT_PRICE, COMPANY_TYPES, INDUSTRIES, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
+import { CapitalistClassState, ClassState, Company, CompanyType, GameState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
 
 export function getIndustry(industryName: IndustryName): Industry {
 	return INDUSTRIES.find(industry => industry.name === industryName)!
+}
+
+export function getCompanyType(company: Company): CompanyType {
+	return COMPANY_TYPES.find(companyType => companyType.name === company.name)!
 }
 
 export function getPlayerClass(playerClassName: PlayerClassName): PlayerClass {
@@ -13,11 +18,11 @@ export function getClassState(gameState: GameState, playerClassName: PlayerClass
 	return gameState.classes.find(x => x.className === playerClassName)!
 }
 
-export function getMaxStorage(classState: ClassState, industry: Industry): number {
+export function getMaxStorage(classState: ClassState, industryName: IndustryName): number {
 	const playerClass: PlayerClass = getPlayerClass(classState.className)
-	const baseStorage: number = playerClass.baseStorages[industry.name]
+	const baseStorage: number = playerClass.baseStorages[industryName]
 	const warehouseStorage: number = ((classState as MiddleClassState | CapitalistClassState).warehouses ?? [])
-		.filter(warehouse => warehouse === industry.name).length * WAREHOUSE_CAPACITIES[industry.name]
+		.filter(warehouse => warehouse === industryName).length * WAREHOUSE_CAPACITIES[industryName]
 	return baseStorage + warehouseStorage
 }
 
@@ -36,6 +41,11 @@ export function getImportTariff(industryName: "Food" | "Luxury", level: number):
 export function getImportPrice(industryName: "Food" | "Luxury", level: number): number {
 	const basePrice = industryName === "Food" ? BASE_FOOD_IMPORT_PRICE : BASE_LUXURY_IMPORT_PRICE
 	return basePrice + getImportTariff(industryName, level)
+}
+
+export function isCompanyOperational(company: Company) {
+	const companyType = getCompanyType(company)
+	return company.workers.length >= companyType.workerSlots.filter(slot => slot.productionBonus === undefined).length
 }
 
 export function getTurn(gameState: GameState) {
@@ -77,4 +87,43 @@ export function changeMoney(classState: ClassState, delta: number) {
 
 export function changeCredibility(gameState: GameState, playerClassName: Exclude<PlayerClassName, "State">, delta: number) {
 	gameState.classes[3].credibility[playerClassName] = Math.max(1, gameState.classes[3].credibility[playerClassName] + delta)
+}
+
+export function changeStoredGoods(classState: ClassState, industryName: IndustryName, delta: number) {
+	classState.storedGoods[industryName].quantity =
+		Math.min(classState.storedGoods[industryName].quantity + delta, getMaxStorage(classState, industryName))
+	if (classState.storedGoods[industryName].quantity < 0)
+		throw new Error(`${classState.className}'s ${industryName} has gone to ${classState.storedGoods[industryName].quantity}`)
+}
+
+export function produceForCompany(gameState: GameState, classState: ClassState, company: Company) {
+	const companyType = getCompanyType(company)
+	const production = sum([
+		companyType.production,
+		...company.workers.map((_, index) => companyType.workerSlots[index].productionBonus ?? 0)
+	])
+	if (classState.className === "Working Class") {
+		classState.consumableGoods[companyType.industry] += production
+	} else {
+		changeStoredGoods(classState, companyType.industry, production)
+	}
+
+	const workerSlotsWithWorker = companyType.workerSlots.map((workerSlot, index) => {
+		return {
+			...workerSlot,
+			worker: company.workers.length > index ? company.workers[index] : undefined
+		}
+	})
+
+	const mainWorkerSlots = workerSlotsWithWorker.filter(workerSlot => workerSlot.productionBonus === undefined)
+	const bonusWorkerSlots = workerSlotsWithWorker.filter(workerSlot => workerSlot.productionBonus !== undefined)
+	;[mainWorkerSlots, bonusWorkerSlots].filter(x => x.length > 0).forEach(workerSlotsGroup => {
+		const takesWage = !(["Machine", "Middle Class"] as Array<WorkerClass | undefined>).includes(workerSlotsGroup[0].classRequirement)
+			&& workerSlotsGroup[0].worker !== undefined
+		if (takesWage) {
+			const wageAmount: number = companyType.wageLevels[company.wageLevel]
+			changeMoney(classState, -wageAmount)
+			changeMoney(getClassState(gameState, workerSlotsGroup[0].worker!.class as PlayerClassName), wageAmount)
+		}
+	})
 }

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -1,5 +1,5 @@
 import _, { sum } from "lodash"
-import { BASE_FOOD_IMPORT_PRICE, BASE_LUXURY_IMPORT_PRICE, COMPANY_TYPES, INDUSTRIES, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
+import { BASE_FOOD_IMPORT_PRICE, BASE_LUXURY_IMPORT_PRICE, COMPANY_TYPES, INDUSTRIES, MAX_EXPORT_ONLY_GOODS, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
 import { CapitalistClassState, ClassState, Company, CompanyType, GameState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
 
 export function getIndustry(industryName: IndustryName): Industry {
@@ -90,10 +90,18 @@ export function changeCredibility(gameState: GameState, playerClassName: Exclude
 }
 
 export function changeStoredGoods(classState: ClassState, industryName: IndustryName, delta: number) {
-	classState.storedGoods[industryName].quantity =
-		Math.min(classState.storedGoods[industryName].quantity + delta, getMaxStorage(classState, industryName))
+	const newQuantityUnbounded: number = classState.storedGoods[industryName].quantity + delta
+	const maxStorage: number = getMaxStorage(classState, industryName)
+	classState.storedGoods[industryName].quantity = Math.min(newQuantityUnbounded, maxStorage)
 	if (classState.storedGoods[industryName].quantity < 0)
 		throw new Error(`${classState.className}'s ${industryName} has gone to ${classState.storedGoods[industryName].quantity}`)
+
+	const exportOnlyGoods = (classState as CapitalistClassState).exportOnlyGoods
+	if (newQuantityUnbounded > maxStorage && exportOnlyGoods !== undefined && industryName in exportOnlyGoods) {
+		const maxExportOnlyGoods: number = MAX_EXPORT_ONLY_GOODS[industryName as keyof CapitalistClassState["exportOnlyGoods"]]
+		exportOnlyGoods[industryName as keyof CapitalistClassState["exportOnlyGoods"]] =
+			Math.min(exportOnlyGoods[industryName as keyof CapitalistClassState["exportOnlyGoods"]] + newQuantityUnbounded - maxStorage, maxExportOnlyGoods)
+	}
 }
 
 export function produceForCompany(gameState: GameState, classState: ClassState, company: Company) {


### PR DESCRIPTION
Changes include:
* Remove unneeded key on WorkerView in PlayerClassPanel
* Add maximum exportOnlyGoods and show that on the PlayerClassPanel
* Make getMaxStorage take IndustryName instead of Industry
* Add getCompanyType helper function so multiple places dont need to do that directly
* Add changeStoredGoods helper function to handle changing the stored goods while respecting the minimum of (0 by throwing an error) and the maximum, and overflowing to exportOnlyGoods (capitalist)
* Add produceForCompany helper for doing a production:
  * Adding the produced goods
  * Paying wages from the company-owning class to the class of the wage-paying workers
* Removed the proposal from the GAME_STATE constant since that was just there to make testing the elections faster, and the elections PR has already been merged
* Updated the GAME_STATE's capitalist luxury stored amount to demonstrate the new changeStoredGoods functionality of overflowing into the exportOnlyGoods

See it at https://democracymanifest.paulapps.dev/

Solves https://github.com/paulbarmstrong/democracy-manifest/issues/19