### PR TITLE
implement the import deal action

### DIFF
--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -1,8 +1,8 @@
-import { GAME_STATE, PLAYER_CLASSES, SIDEBAR_WIDTH_PX } from "../utilities/Constants"
+import { GAME_STATE, IMPORT_DEALS, PLAYER_CLASSES, SIDEBAR_WIDTH_PX } from "../utilities/Constants"
 import { useWindowSize } from "../hooks/useWindowSize"
 import { DynamicWebappConfig } from "common"
 import { useRefState } from "../hooks/useRefState"
-import { Action, ActionExecution, PlayerClassName, PolicyPosition, TabName } from "../utilities/Types"
+import { Action, ActionExecution, ImportDeal, PlayerClassName, PolicyPosition, PreferredImportDealDestination, TabName } from "../utilities/Types"
 import { playerClassNameZod, tabNameZod } from "../utilities/Zod"
 import { getClassState, getPlayerClass } from "../utilities/Game"
 import { getPlayerColor, getShade } from "../utilities/Color"
@@ -78,10 +78,13 @@ export function App(props: Props) {
 	async function onClickAction(action: Action) {
 		actionExecution.current = {action}
 		if (action.execute !== undefined) await action.execute({
-			gameState,
+			gameState: gameState.current,
 			playerClass: observingAsPlayerClass,
 			classState: getClassState(gameState.current, observingAsPlayerClass.name),
-			setText: text => actionExecution.current = {...actionExecution.current!, text}, selectPolicyPosition
+			setText: text => actionExecution.current = {...actionExecution.current!, text},
+			selectPolicyPosition,
+			selectImportDeal,
+			selectPreferredImportDealDestination
 		})
 		if (action.type === "free") {
 			gameState.current.freeActionCompleted = true
@@ -96,6 +99,20 @@ export function App(props: Props) {
 		selectedTab.current = "Politics"
 		return new Promise<PolicyPosition>((resolve, _) => {
 			actionExecution.current = {...actionExecution.current!, policyPositionPredicate: predicate, policyPositionCallback: resolve}
+		})
+	}
+
+	async function selectImportDeal(predicate: (importDeal: ImportDeal) => boolean): Promise<ImportDeal> {
+		selectedTab.current = "Marketplace"
+		return new Promise<ImportDeal>((resolve, _) => {
+			actionExecution.current = {...actionExecution.current!, importDealPredicate: predicate, importDealCallback: resolve}
+		})
+	}
+
+	async function selectPreferredImportDealDestination(): Promise<PreferredImportDealDestination> {
+		selectedTab.current = "My Class"
+		return new Promise<PreferredImportDealDestination>((resolve, _) => {
+			actionExecution.current = {...actionExecution.current!, preferredImportDealDestinationCallback: resolve}
 		})
 	}
 
@@ -125,11 +142,11 @@ export function App(props: Props) {
 						if (selectedTab.current === "All Classes") {
 							return <AllPlayerClassesPanel gameState={gameState.current}/>
 						} else if (selectedTab.current === "My Class") {
-							return <PlayerClassPanel playerClass={getPlayerClass(observingAsPlayerClassName.current)} gameState={gameState.current} zoomed={true}/>
+							return <PlayerClassPanel playerClass={getPlayerClass(observingAsPlayerClassName.current)} gameState={gameState.current} zoomed={true} actionExecution={actionExecution.current}/>
 						} else if (selectedTab.current === "Politics") {
 							return <PoliticsPanel playerClassName={observingAsPlayerClassName.current} updateGameState={updateGameState} gameState={gameState.current} actionExecution={actionExecution.current}/>
 						} else if (selectedTab.current === "Marketplace") {
-							return <MarketplacePanel gameState={gameState.current}/>
+							return <MarketplacePanel gameState={gameState.current} actionExecution={actionExecution.current}/>
 						} else if (selectedTab.current === "Actions") {
 							return <ActionsPanel gameState={gameState.current} playerClass={observingAsPlayerClass} onClickAction={onClickAction}/>
 						}

--- a/packages/webapp/src/components/panels/MarketplacePanel.tsx
+++ b/packages/webapp/src/components/panels/MarketplacePanel.tsx
@@ -1,14 +1,22 @@
 import { groupBy } from "lodash"
 import { getColor, getShade } from "../../utilities/Color"
 import { EXPORT_DEALS, IMPORT_DEALS, INDUSTRIES } from "../../utilities/Constants"
-import { getImportPrice, getIndustry, getPlayerClass } from "../../utilities/Game"
-import { GameState, IndustryName } from "../../utilities/Types"
+import { getImportDealPrice, getImportDealTariff, getImportPrice, getIndustry, getPlayerClass } from "../../utilities/Game"
+import { ActionExecution, GameState, ImportDeal, IndustryName } from "../../utilities/Types"
 import { Details } from "../Details"
+import { Highlight } from "../Highlight"
 import { Icon } from "../Icon"
 
 export function MarketplacePanel(props: {
-	gameState: GameState
+	gameState: GameState,
+	actionExecution: ActionExecution | undefined
 }) {
+	function onClickImportDeal(importDeal: ImportDeal) {
+		if (props.actionExecution?.importDealPredicate !== undefined && props.actionExecution.importDealPredicate(importDeal)) {
+			props.actionExecution.importDealCallback!(importDeal)
+		}
+	}
+
 	return <div style={{backgroundColor: getShade(1), padding: 10}}>
 		<Details details={[
 			...INDUSTRIES.map(industry => ({
@@ -61,9 +69,14 @@ export function MarketplacePanel(props: {
 			{name: "Import deals", content:
 				<div style={{display: "flex", flexDirection: "column", gap: 10}}>
 					{
-						props.gameState.importDeals.map(i => IMPORT_DEALS[i]).map(importDeal => <span style={{display: "flex", alignItems: "center", gap: 3}}>
-							Capitalist may purchase <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Food").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.foodQuantity} <Icon name="Food" gap={3}/></span> + <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Luxury").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.luxuryQuantity} <Icon name="Luxury" gap={3}/></span> for ${importDeal.cost[props.gameState.policies["Foreign Trade"].state]}
-						</span>)
+						props.gameState.importDeals.map(i => IMPORT_DEALS[i]).map(importDeal => {
+							const selectable = props.actionExecution?.importDealPredicate !== undefined && props.actionExecution.importDealPredicate(importDeal)
+							return <Highlight active={selectable}>
+								<span className={selectable ? "clickable" : undefined} onClick={selectable ? () => onClickImportDeal(importDeal) : undefined} style={{display: "flex", alignItems: "center", gap: 3}}>
+									Capitalist may purchase <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Food").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.foodQuantity} <Icon name="Food" gap={3}/></span> + <span style={{display: "flex", alignItems: "center", backgroundColor: getColor(getIndustry("Luxury").hue, 0), borderRadius: 4, padding: 10}}>{importDeal.luxuryQuantity} <Icon name="Luxury" gap={3}/></span> for ${getImportDealPrice(props.gameState, importDeal)} (includes ${getImportDealTariff(props.gameState, importDeal)} in tariffs)
+								</span>
+							</Highlight>
+						})
 					}
 				</div>
 			},

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -1,6 +1,6 @@
 import { range } from "lodash"
 import { getColor, getPlayerColor } from "../../utilities/Color"
-import { CapitalistClassState, GameState, IndustryName, PlayerClass, PlayerClassName, StateClassState, Worker, WorkingClassState } from "../../utilities/Types"
+import { ActionExecution, CapitalistClassState, GameState, IndustryName, PlayerClass, PlayerClassName, PreferredImportDealDestination, StateClassState, Worker, WorkingClassState } from "../../utilities/Types"
 import { COMPANY_SIZE_PX, INDUSTRIES, MAX_CREDIBILITY_PER_CLASS, MAX_EXPORT_ONLY_GOODS, WEALTH_TIER_THRESHOLDS, WORKER_SIZE_PX } from "../../utilities/Constants"
 import { CompanyCard } from "../CompanyCard"
 import { capitalToWealthTier, getIndustry, getMaxStorage, getTurn } from "../../utilities/Game"
@@ -13,11 +13,20 @@ import { Highlight } from "../Highlight"
 interface Props {
 	playerClass: PlayerClass,
 	gameState: GameState,
-	zoomed: boolean
+	zoomed: boolean,
+	actionExecution?: ActionExecution
 }
 
 export function PlayerClassPanel(props: Props) {
 	const classState = props.gameState.classes.find(clazz => clazz.className === props.playerClass.name)!
+
+	const selectingImportDealDestination = props.actionExecution?.preferredImportDealDestinationCallback !== undefined
+
+	function onClickImportDealDestination(destination: PreferredImportDealDestination) {
+		if (props.actionExecution?.preferredImportDealDestinationCallback !== undefined) {
+			props.actionExecution.preferredImportDealDestinationCallback(destination)
+		}
+	}
 	const unionLeaderWorkers: Array<Worker> | undefined = (classState as WorkingClassState).unionLeaders !== undefined ? (
 		Object.values((classState as WorkingClassState).unionLeaders)
 	) : (
@@ -42,34 +51,38 @@ export function PlayerClassPanel(props: Props) {
 			{name: "Number of workers", content: numberOfWorkers},
 			{name: "Population level", content: populationLevel},
 			{name: "Stored goods", content: INDUSTRIES.filter(industry => getMaxStorage(classState, industry.name) > 0).length > 0 ? (
-				<div style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
-					{
-						INDUSTRIES.filter(industry => getMaxStorage(classState, industry.name) > 0).map(industry => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(industry.hue, 0), padding: 10, gap: 10, borderRadius: 4}}>
-							<Icon name={industry.name}/>
-							<span>{classState.storedGoods[industry.name].quantity}/{getMaxStorage(classState, industry.name)}</span>
-							<RadioSelector
-								choices={props.playerClass.storagePriceOptions[industry.name].map(price => ({value: price, content: `$${price}`})).reverse()}
-								onChange={() => undefined}
-								value={classState.storedGoods[industry.name].price}
-								radioButtonSize={16}
-								fontSize="small"
-							/>
-						</div>)
-					}
-				</div>
+				<Highlight active={selectingImportDealDestination}>
+					<div className={selectingImportDealDestination ? "clickable" : undefined} onClick={selectingImportDealDestination ? () => onClickImportDealDestination("regularStorage") : undefined} style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
+						{
+							INDUSTRIES.filter(industry => getMaxStorage(classState, industry.name) > 0).map(industry => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(industry.hue, 0), padding: 10, gap: 10, borderRadius: 4}}>
+								<Icon name={industry.name}/>
+								<span>{classState.storedGoods[industry.name].quantity}/{getMaxStorage(classState, industry.name)}</span>
+								<RadioSelector
+									choices={props.playerClass.storagePriceOptions[industry.name].map(price => ({value: price, content: `$${price}`})).reverse()}
+									onChange={() => undefined}
+									value={classState.storedGoods[industry.name].price}
+									radioButtonSize={16}
+									fontSize="small"
+								/>
+							</div>)
+						}
+					</div>
+				</Highlight>
 			) : (
 				undefined
 			)},
 			{name: "Export-only goods", content: (classState as CapitalistClassState).exportOnlyGoods !== undefined ? (
-				<div style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
-					{
-						(Object.entries((classState as CapitalistClassState).exportOnlyGoods) as Array<[IndustryName, number]>)
-							.map(([industryName, quantity]) => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(getIndustry(industryName).hue, 0), padding: 10, gap: 10, borderRadius: 4, width: 40}}>
-								<Icon name={industryName as any}/>
-								<span>{quantity}/{MAX_EXPORT_ONLY_GOODS[industryName as keyof CapitalistClassState["exportOnlyGoods"]]}</span>
-							</div>)
-					}
-				</div>
+				<Highlight active={selectingImportDealDestination}>
+					<div className={selectingImportDealDestination ? "clickable" : undefined} onClick={selectingImportDealDestination ? () => onClickImportDealDestination("exportOnlyStorage") : undefined}  style={{display: "flex", gap: 5, borderColor: "white", borderWidth: 2, borderRadius: 4}}>
+						{
+							(Object.entries((classState as CapitalistClassState).exportOnlyGoods) as Array<[IndustryName, number]>)
+								.map(([industryName, quantity]) => <div style={{display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "center", backgroundColor: getColor(getIndustry(industryName).hue, 0), padding: 10, gap: 10, borderRadius: 4, width: 40}}>
+									<Icon name={industryName as any}/>
+									<span>{quantity}/{MAX_EXPORT_ONLY_GOODS[industryName as keyof CapitalistClassState["exportOnlyGoods"]]}</span>
+								</div>)
+						}
+					</div>
+				</Highlight>
 			) : (
 				undefined
 			)},

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -1,6 +1,6 @@
 import { range, take } from "lodash"
-import { Action, CompanyType, ExportDeals, GameState, ImportDeal, Industry, PlayerClass, PlayerClassName, Policy, StateClassState } from "./Types"
-import { changeCredibility, changeMoney, getClassState, getImportPrice, getIndustry } from "./Game"
+import { Action, CapitalistClassState, CompanyType, ExportDeals, GameState, ImportDeal, Industry, PlayerClass, PlayerClassName, Policy, StateClassState } from "./Types"
+import { changeCredibility, changeMoney, changeStoredGoods, getClassState, getImportDealPrice, getImportDealTariff, getImportPrice, getIndustry } from "./Game"
 import { isAre, s } from "./Misc"
 
 export const COMPANY_SIZE_PX = 220
@@ -139,20 +139,14 @@ export const IMPORT_DEALS: Array<ImportDeal> = [
 	{
 		foodQuantity: 7,
 		luxuryQuantity: 5,
-		cost: {
-			0: 84,
-			1: 82,
-			2: 70
-		}
+		baseCost: 70,
+		tariffPerForeignTradePosition: 12
 	},
 	{
 		foodQuantity: 0,
 		luxuryQuantity: 8,
-		cost: {
-			0: 46,
-			1: 38,
-			2: 30
-		}
+		baseCost: 30,
+		tariffPerForeignTradePosition: 8
 	}
 ]
 
@@ -266,8 +260,8 @@ export const BASIC_ACTIONS: Array<Action> = [
 		isPossible: ({gameState}) => Object.values(gameState.policies).filter(x => x.proposal !== undefined).length < 3,
 		execute: async ({gameState, playerClass, setText, selectPolicyPosition}) => {
 			setText("Select a policy position adjacent to that policy's existing position.")
-			const policyPosition = await selectPolicyPosition(policyPosition => Math.abs(gameState.current.policies[policyPosition.name].state - policyPosition.position) === 1 && gameState.current.policies[policyPosition.name].proposal === undefined)
-			gameState.current.policies[policyPosition.name].proposal = {playerClassName: playerClass.name, proposedState: policyPosition.position}
+			const policyPosition = await selectPolicyPosition(policyPosition => Math.abs(gameState.policies[policyPosition.name].state - policyPosition.position) === 1 && gameState.policies[policyPosition.name].proposal === undefined)
+			gameState.policies[policyPosition.name].proposal = {playerClassName: playerClass.name, proposedState: policyPosition.position}
 		}
 	},
 	{name: "Address event", type: "basic", playerClasses: ["State"], description: "Address one of the State events."},
@@ -277,14 +271,14 @@ export const BASIC_ACTIONS: Array<Action> = [
 		playerClasses: ["State"],
 		description: "Get $10 from each class and -1 <credibility> from the 2 classes with the lowest <credibility>.",
 		execute: async ({gameState, classState}) => {
-			gameState.current.classes.filter(otherClassState => otherClassState.className !== "State").forEach(otherClassState => {
+			gameState.classes.filter(otherClassState => otherClassState.className !== "State").forEach(otherClassState => {
 				changeMoney(otherClassState, -10)
 				changeMoney(classState, 10)
 			})
 			const stateClassState = classState as StateClassState
 			const highestCredibilityPlayerClassName = Object.entries(stateClassState.credibility).sort((a, b) => b[1] - a[1])[0][0]
 			PLAYER_CLASSES.filter(x => !["State", highestCredibilityPlayerClassName].includes(x.name)).forEach(playerClass => {
-				changeCredibility(gameState.current, playerClass.name as Exclude<PlayerClassName, "State">, -1)
+				changeCredibility(gameState, playerClass.name as Exclude<PlayerClassName, "State">, -1)
 			})
 		}
 	},
@@ -293,7 +287,31 @@ export const BASIC_ACTIONS: Array<Action> = [
 	{name: "Purchase company", type: "basic", playerClasses: ["Middle Class", "Capitalist Class"], description: "Purchase a company from your company market for its listed price."},
 	{name: "Sell company", type: "basic", playerClasses: ["Middle Class", "Capitalist Class"], description: "Remove one of your companies and gain its listed price."},
 	{name: "Make export deals", type: "basic", playerClasses: ["Middle Class", "Capitalist Class", "State"], description: "Complete any number of export deals a maximum of 1 time."},
-	{name: "Make import deal", type: "basic", playerClasses: ["Capitalist Class"], description: "Perform an import deal once."},
+	{name: "Make import deal",
+		type: "basic",
+		playerClasses: ["Capitalist Class"],
+		description: "Perform an import deal once.",
+		isPossible: ({gameState}) => {
+			const importDeals: Array<ImportDeal> = gameState.importDeals.map(index => IMPORT_DEALS[index])
+			const capitalistClassState: CapitalistClassState = getClassState(gameState, "Capitalist Class") as CapitalistClassState
+			return importDeals
+				.filter(importDeal => getImportDealPrice(gameState, importDeal) < capitalistClassState.cash + capitalistClassState.capital)
+				.length > 1
+		},
+		execute: async ({gameState, setText, selectImportDeal, selectPreferredImportDealDestination}) => {
+			setText("Select an import deal.")
+			const capitalistClassState: CapitalistClassState = getClassState(gameState, "Capitalist Class") as CapitalistClassState
+			const importDeal: ImportDeal = await selectImportDeal(importDeal => {
+				return getImportDealPrice(gameState, importDeal) < capitalistClassState.cash + capitalistClassState.capital
+			})
+			setText("Select preferred storage location.")
+			const storageDestination = await selectPreferredImportDealDestination()
+			changeStoredGoods(capitalistClassState, "Food", importDeal.foodQuantity, storageDestination === "exportOnlyStorage")
+			changeStoredGoods(capitalistClassState, "Luxury", importDeal.luxuryQuantity, storageDestination === "exportOnlyStorage")
+			changeMoney(capitalistClassState, -getImportDealPrice(gameState, importDeal))
+			changeMoney(getClassState(gameState, "State"), getImportDealTariff(gameState, importDeal))
+		}
+	},
 	{name: "Lobby", type: "basic", playerClasses: ["Capitalist Class"], description: "Spend $30 from capital to gain 3 <Influence>"},
 	{name: "Buy goods", type: "basic", playerClasses: ["Working Class", "Middle Class"], description: "Buy a single type of good from up to two sellers. The number of goods must be less than or equal to your population."},
 	{name: "Work extra shift", type: "basic", playerClasses: ["Middle Class"], description: "Choose one of your companies with non-committed Middle Class workers. Pay wages and produce."},
@@ -306,9 +324,9 @@ export const BASIC_ACTIONS: Array<Action> = [
 		description: "Add 3 political pressure (up to a maximum of 25).",
 		execute: async ({gameState, playerClass}) => {
 			const playerClassName = playerClass.name as "Working Class" | "Middle Class" | "Capitalist Class"
-			const currentClassPoliticalPressure = gameState.current.politicalPressure.filter(x => x === playerClassName).length
+			const currentClassPoliticalPressure = gameState.politicalPressure.filter(x => x === playerClassName).length
 			const numAddedPoliticalPressure = Math.min(25 - currentClassPoliticalPressure, 3)
-			gameState.current.politicalPressure.push(...range(0, numAddedPoliticalPressure).map(_ => playerClassName))
+			gameState.politicalPressure.push(...range(0, numAddedPoliticalPressure).map(_ => playerClassName))
 		}
 	}
 ]
@@ -333,7 +351,7 @@ export const FREE_ACTIONS: Array<Action> = [
 		},
 		execute: async ({gameState, playerClass, classState}) => {
 			const playerClassName = playerClass.name as "Working Class" | "Middle Class" | "Capitalist Class"
-			const stateClassState: StateClassState = getClassState(gameState.current, "State") as StateClassState
+			const stateClassState: StateClassState = getClassState(gameState, "State") as StateClassState
 			classState.cash += stateClassState.stateBenefits[playerClassName]
 			stateClassState.stateBenefits[playerClassName] = 0
 		}
@@ -361,7 +379,7 @@ export const FREE_ACTIONS: Array<Action> = [
 ]
 
 export const GAME_STATE: GameState = {
-	turnIndex: 19,
+	turnIndex: 18,
 	mainActionCompleted: false,
 	freeActionCompleted: false,
 	policies: {

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -1,6 +1,6 @@
 import _, { sum } from "lodash"
 import { BASE_FOOD_IMPORT_PRICE, BASE_LUXURY_IMPORT_PRICE, COMPANY_TYPES, INDUSTRIES, MAX_EXPORT_ONLY_GOODS, PLAYER_CLASSES, WAREHOUSE_CAPACITIES, WEALTH_TIER_THRESHOLDS } from "./Constants"
-import { CapitalistClassState, ClassState, Company, CompanyType, GameState, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
+import { CapitalistClassState, ClassState, Company, CompanyType, GameState, ImportDeal, Industry, IndustryName, MiddleClassState, PlayerClass, PlayerClassName, WorkerClass } from "./Types"
 
 export function getIndustry(industryName: IndustryName): Industry {
 	return INDUSTRIES.find(industry => industry.name === industryName)!
@@ -42,6 +42,15 @@ export function getImportPrice(industryName: "Food" | "Luxury", level: number): 
 	const basePrice = industryName === "Food" ? BASE_FOOD_IMPORT_PRICE : BASE_LUXURY_IMPORT_PRICE
 	return basePrice + getImportTariff(industryName, level)
 }
+
+export function getImportDealTariff(gameState: GameState, importDeal: ImportDeal): number {
+	return importDeal.tariffPerForeignTradePosition * (2 - gameState.policies["Foreign Trade"].state)
+}
+
+export function getImportDealPrice(gameState: GameState, importDeal: ImportDeal): number {
+	return importDeal.baseCost + getImportDealTariff(gameState, importDeal)
+}
+
 
 export function isCompanyOperational(company: Company) {
 	const companyType = getCompanyType(company)
@@ -89,18 +98,28 @@ export function changeCredibility(gameState: GameState, playerClassName: Exclude
 	gameState.classes[3].credibility[playerClassName] = Math.max(1, gameState.classes[3].credibility[playerClassName] + delta)
 }
 
-export function changeStoredGoods(classState: ClassState, industryName: IndustryName, delta: number) {
-	const newQuantityUnbounded: number = classState.storedGoods[industryName].quantity + delta
+export function changeStoredGoods(classState: ClassState, industryName: IndustryName, delta: number, preferExportOnlyGoods: boolean) {
+	const exportOnlyGoods = (classState as CapitalistClassState).exportOnlyGoods
+	const hasExportOnlyGoods = exportOnlyGoods !== undefined && industryName in exportOnlyGoods
+	const exportOnlyGoodsKey = industryName as keyof CapitalistClassState["exportOnlyGoods"]
 	const maxStorage: number = getMaxStorage(classState, industryName)
+
+	if (preferExportOnlyGoods && hasExportOnlyGoods && delta > 0) {
+		const maxExportOnlyGoods: number = MAX_EXPORT_ONLY_GOODS[exportOnlyGoodsKey]
+		const addedToExportOnlyGoods = Math.min(delta, maxExportOnlyGoods - exportOnlyGoods[exportOnlyGoodsKey])
+		exportOnlyGoods[exportOnlyGoodsKey] += addedToExportOnlyGoods
+		delta -= addedToExportOnlyGoods
+	}
+
+	const newQuantityUnbounded: number = classState.storedGoods[industryName].quantity + delta
 	classState.storedGoods[industryName].quantity = Math.min(newQuantityUnbounded, maxStorage)
 	if (classState.storedGoods[industryName].quantity < 0)
 		throw new Error(`${classState.className}'s ${industryName} has gone to ${classState.storedGoods[industryName].quantity}`)
 
-	const exportOnlyGoods = (classState as CapitalistClassState).exportOnlyGoods
-	if (newQuantityUnbounded > maxStorage && exportOnlyGoods !== undefined && industryName in exportOnlyGoods) {
-		const maxExportOnlyGoods: number = MAX_EXPORT_ONLY_GOODS[industryName as keyof CapitalistClassState["exportOnlyGoods"]]
-		exportOnlyGoods[industryName as keyof CapitalistClassState["exportOnlyGoods"]] =
-			Math.min(exportOnlyGoods[industryName as keyof CapitalistClassState["exportOnlyGoods"]] + newQuantityUnbounded - maxStorage, maxExportOnlyGoods)
+	if (newQuantityUnbounded > maxStorage && hasExportOnlyGoods) {
+		const maxExportOnlyGoods: number = MAX_EXPORT_ONLY_GOODS[exportOnlyGoodsKey]
+		exportOnlyGoods[exportOnlyGoodsKey] =
+			Math.min(exportOnlyGoods[exportOnlyGoodsKey] + newQuantityUnbounded - maxStorage, maxExportOnlyGoods)
 	}
 }
 
@@ -113,7 +132,7 @@ export function produceForCompany(gameState: GameState, classState: ClassState, 
 	if (classState.className === "Working Class") {
 		classState.consumableGoods[companyType.industry] += production
 	} else {
-		changeStoredGoods(classState, companyType.industry, production)
+		changeStoredGoods(classState, companyType.industry, production, false)
 	}
 
 	const workerSlotsWithWorker = companyType.workerSlots.map((workerSlot, index) => {

--- a/packages/webapp/src/utilities/Types.ts
+++ b/packages/webapp/src/utilities/Types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 import { playerClassNameZod, tabNameZod } from "./Zod"
-import { ImmutableRefObject } from "../classes/ImmutableRefObject"
 
 export type PlayerClassName = z.infer<typeof playerClassNameZod>
 
@@ -131,11 +130,8 @@ export type StateClassState = CommonClassState & {
 export type ImportDeal = {
 	foodQuantity: number,
 	luxuryQuantity: number,
-	cost: {
-		0: number,
-		1: number,
-		2: number
-	}
+	baseCost: number,
+	tariffPerForeignTradePosition: number
 }
 
 export type ExportDeals = Array<{
@@ -190,11 +186,13 @@ export type Action = {
 		classState: ClassState
 	}) => boolean,
 	execute?: (args: {
-		gameState: ImmutableRefObject<GameState>,
+		gameState: GameState,
 		playerClass: PlayerClass,
 		classState: ClassState,
 		setText: (text: string) => void,
-		selectPolicyPosition: (predicate: (policyPosition: PolicyPosition) => boolean) => Promise<PolicyPosition>
+		selectPolicyPosition: (predicate: (policyPosition: PolicyPosition) => boolean) => Promise<PolicyPosition>,
+		selectImportDeal: (predicate: (importDeal: ImportDeal) => boolean) => Promise<ImportDeal>
+		selectPreferredImportDealDestination: () => Promise<PreferredImportDealDestination>
 	}) => Promise<void>
 }
 
@@ -202,6 +200,9 @@ export type ActionExecution = {
 	action: Action,
 	policyPositionPredicate?: (policyPosition: PolicyPosition) => boolean,
 	policyPositionCallback?: (policyPosition: PolicyPosition) => void,
+	importDealPredicate?: (importDeal: ImportDeal) => boolean,
+	importDealCallback?: (preference: ImportDeal) => void,
+	preferredImportDealDestinationCallback?: (preference: PreferredImportDealDestination) => void,
 	text?: string
 }
 
@@ -215,3 +216,5 @@ export type PolicyPosition = {
 	name: PolicyName,
 	position: 0 | 1 | 2
 }
+
+export type PreferredImportDealDestination = "regularStorage" | "exportOnlyStorage"


### PR DESCRIPTION
Changes include:
* Make Action's execute function take GameState instead of ImmutableRefState<GameState> since we dont need to worry about the reference expiring in thereZ
* Add new Action and ActionExecution parameters to facilitate the import deal action
* Update changeStoredGoods to be able to prefer the exportOnlyGoods (depending on the decision in the import deal action)
* Move GAME_STATE's turnIndex back by 1 so that it's the capitalist's turn so it easier to try this action. Happy to have it be moved to another one in a later commit
* Add tariff amount to the import deals shown on the Marketplace tab

See it at https://democracymanifest.paulapps.dev/

Solves https://github.com/paulbarmstrong/democracy-manifest/issues/13