### PR TITLE
implement strike

### DIFF
--- a/packages/webapp/.gitignore
+++ b/packages/webapp/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.pdf

--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -2,7 +2,7 @@ import { GAME_STATE, IMPORT_DEALS, PLAYER_CLASSES, SIDEBAR_WIDTH_PX } from "../u
 import { useWindowSize } from "../hooks/useWindowSize"
 import { DynamicWebappConfig } from "common"
 import { useRefState } from "../hooks/useRefState"
-import { Action, ActionExecution, ImportDeal, PlayerClassName, PolicyPosition, PreferredImportDealDestination, TabName } from "../utilities/Types"
+import { Action, ActionExecution, Company, ImportDeal, PlayerClassName, PolicyPosition, PreferredImportDealDestination, TabName } from "../utilities/Types"
 import { playerClassNameZod, tabNameZod } from "../utilities/Zod"
 import { getClassState, getPlayerClass } from "../utilities/Game"
 import { getPlayerColor, getShade } from "../utilities/Color"
@@ -84,7 +84,8 @@ export function App(props: Props) {
 			setText: text => actionExecution.current = {...actionExecution.current!, text},
 			selectPolicyPosition,
 			selectImportDeal,
-			selectPreferredImportDealDestination
+			selectPreferredImportDealDestination,
+			selectCompany
 		})
 		if (action.type === "free") {
 			gameState.current.freeActionCompleted = true
@@ -116,6 +117,13 @@ export function App(props: Props) {
 		})
 	}
 
+	async function selectCompany(predicate: (company: Company) => boolean): Promise<Company | undefined> {
+		selectedTab.current = "All Classes"
+		return new Promise<Company | undefined>((resolve, _) => {
+			actionExecution.current = {...actionExecution.current!, companyPredicate: predicate, companyCallback: resolve}
+		})
+	}
+
 	return (
 		<div style={{display: "flex", userSelect: "none"}}>
 			<Sidebar />
@@ -140,7 +148,7 @@ export function App(props: Props) {
 				{
 					(() => {
 						if (selectedTab.current === "All Classes") {
-							return <AllPlayerClassesPanel gameState={gameState.current}/>
+							return <AllPlayerClassesPanel gameState={gameState.current} actionExecution={actionExecution.current}/>
 						} else if (selectedTab.current === "My Class") {
 							return <PlayerClassPanel playerClass={getPlayerClass(observingAsPlayerClassName.current)} gameState={gameState.current} zoomed={true} actionExecution={actionExecution.current}/>
 						} else if (selectedTab.current === "Politics") {
@@ -157,6 +165,13 @@ export function App(props: Props) {
 						<div style={{position: "fixed", bottom: 0, left: SIDEBAR_WIDTH_PX, right: 0, display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", gap: 20, padding: 20, backgroundColor: getShade(2)}}>
 							<span style={{fontSize: "x-large", fontWeight: "bold"}}>{actionExecution.current.action.name}</span>
 							{actionExecution.current.text}
+							{
+								actionExecution.current.companyCallback !== undefined ? (
+									<div className="clickable" onClick={() => actionExecution.current!.companyCallback!(undefined)} style={{padding: 10, borderRadius: 4, backgroundColor: getShade(1), fontWeight: "bold"}}>Done</div>
+								) : (
+									undefined
+								)
+							}
 						</div>
 					) : (
 						undefined

--- a/packages/webapp/src/components/CompanyCard.tsx
+++ b/packages/webapp/src/components/CompanyCard.tsx
@@ -1,6 +1,6 @@
 import { sum } from "lodash"
 import { getColor } from "../utilities/Color"
-import { COMPANY_SIZE_PX, INDUSTRIES } from "../utilities/Constants"
+import { COMPANY_SIZE_PX, INDUSTRIES, STRIKE_COLOR } from "../utilities/Constants"
 import { Company, WorkerClass } from "../utilities/Types"
 import { RadioSelector } from "./RadioSelector"
 import { WorkerView } from "./WorkerView"
@@ -8,7 +8,9 @@ import { Icon } from "./Icon"
 import { getCompanyType } from "../utilities/Game"
 
 interface Props {
-	company: Company
+	company: Company,
+	selectable?: boolean,
+	onSelect?: () => void
 }
 
 export function CompanyCard(props: Props) {
@@ -16,8 +18,21 @@ export function CompanyCard(props: Props) {
 	const industry = INDUSTRIES.find(industry => industry.name === companyType.industry)!
 	const mainWorkerSlots = companyType.workerSlots.filter(workerSlot => workerSlot.productionBonus === undefined)
 	const bonusWorkerSlots = companyType.workerSlots.filter(workerSlot => workerSlot.productionBonus !== undefined)
-	return <div style={{position: "relative", width: COMPANY_SIZE_PX, height: COMPANY_SIZE_PX, backgroundColor: getColor(industry.hue, 0), boxSizing: "border-box", borderRadius: 4}}>
+	return <div
+		className={props.selectable ? "clickable" : undefined}
+		onClick={props.selectable ? props.onSelect : undefined}
+		style={{position: "relative", width: COMPANY_SIZE_PX, height: COMPANY_SIZE_PX, backgroundColor: getColor(industry.hue, 0), boxSizing: "border-box", borderRadius: 4, outline: props.selectable ? "2px solid white" : undefined, outlineOffset: 2}}
+	>
 		<div style={{position: "absolute", top: 0, right: 0, borderRadius: 4, backgroundColor: getColor(industry.hue, 1), padding: 4, fontSize: "small"}}>${companyType.price}</div>
+		{
+			props.company.onStrike ? (
+				<div style={{position: "absolute", top: 4, left: 4, display: "flex", alignItems: "center", gap: 3, backgroundColor: STRIKE_COLOR, color: "white", padding: 4, borderRadius: 4}}>
+					<span className="material-symbols-outlined" style={{fontSize: 16, fontVariationSettings: "'FILL' 1"}}>front_hand</span>
+				</div>
+			) : (
+				undefined
+			)
+		}
 		<div style={{width: "100%", height: "100%", backgroundColor: getColor(industry.hue, 0), display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "center", borderRadius: 4, padding: 10, boxSizing: "border-box"}}>
 			<span>{props.company.name}</span>
 			<div style={{display: "flex", justifyContent: "center", alignItems: "flex-start", gap: 5}}>

--- a/packages/webapp/src/components/panels/AllPlayerClassesPanel.tsx
+++ b/packages/webapp/src/components/panels/AllPlayerClassesPanel.tsx
@@ -1,20 +1,21 @@
 import { PLAYER_CLASSES } from "../../utilities/Constants"
-import { GameState } from "../../utilities/Types"
+import { ActionExecution, GameState } from "../../utilities/Types"
 import { getShade } from "../../utilities/Color"
 import { PlayerClassPanel } from "./PlayerClassPanel"
 
 export function AllPlayerClassesPanel(props: {
-    gameState: GameState
+    gameState: GameState,
+    actionExecution?: ActionExecution
 }) {
     return <div style={{display: "flex", flexDirection: "column"}}>
         <div style={{height: 20, backgroundColor: getShade(1)}}></div>
         <div style={{display: "flex"}}>
-            <PlayerClassPanel playerClass={PLAYER_CLASSES[0]} gameState={props.gameState} zoomed={false}/>
-            <PlayerClassPanel playerClass={PLAYER_CLASSES[1]} gameState={props.gameState} zoomed={false}/>
+            <PlayerClassPanel playerClass={PLAYER_CLASSES[0]} gameState={props.gameState} zoomed={false} actionExecution={props.actionExecution}/>
+            <PlayerClassPanel playerClass={PLAYER_CLASSES[1]} gameState={props.gameState} zoomed={false} actionExecution={props.actionExecution}/>
         </div>
         <div style={{display: "flex"}}>
-            <PlayerClassPanel playerClass={PLAYER_CLASSES[2]} gameState={props.gameState} zoomed={false}/>
-            <PlayerClassPanel playerClass={PLAYER_CLASSES[3]} gameState={props.gameState} zoomed={false}/>
+            <PlayerClassPanel playerClass={PLAYER_CLASSES[2]} gameState={props.gameState} zoomed={false} actionExecution={props.actionExecution}/>
+            <PlayerClassPanel playerClass={PLAYER_CLASSES[3]} gameState={props.gameState} zoomed={false} actionExecution={props.actionExecution}/>
         </div>
     </div>
 }

--- a/packages/webapp/src/components/panels/PlayerClassPanel.tsx
+++ b/packages/webapp/src/components/panels/PlayerClassPanel.tsx
@@ -27,6 +27,8 @@ export function PlayerClassPanel(props: Props) {
 			props.actionExecution.preferredImportDealDestinationCallback(destination)
 		}
 	}
+
+	const selectingCompany = props.actionExecution?.companyCallback !== undefined
 	const unionLeaderWorkers: Array<Worker> | undefined = (classState as WorkingClassState).unionLeaders !== undefined ? (
 		Object.values((classState as WorkingClassState).unionLeaders)
 	) : (
@@ -191,7 +193,14 @@ export function PlayerClassPanel(props: Props) {
 					{
 						range(0, props.playerClass.maxCompanies).map(companyIndex => {
 							if (companyIndex < classState.companies.length) {
-								return <CompanyCard key={companyIndex} company={classState.companies[companyIndex]}/>
+								const company = classState.companies[companyIndex]
+								const selectable = selectingCompany && (props.actionExecution?.companyPredicate?.(company) ?? false)
+								return <CompanyCard
+									key={companyIndex}
+									company={company}
+									selectable={selectable}
+									onSelect={selectable ? () => props.actionExecution!.companyCallback!(company) : undefined}
+								/>
 							} else {
 								return <div style={{width: COMPANY_SIZE_PX, height: COMPANY_SIZE_PX, backgroundColor: getColor(props.playerClass.hue, 1), borderRadius: 4}}/>
 							}

--- a/packages/webapp/src/hooks/useGameState.ts
+++ b/packages/webapp/src/hooks/useGameState.ts
@@ -2,7 +2,7 @@ import { clone, shuffle, sum } from "lodash"
 import { ImmutableRefObject } from "../classes/ImmutableRefObject"
 import { GameState, PolicyName } from "../utilities/Types"
 import { useRefState } from "./useRefState"
-import { getTurn, isCompanyOperational, produceForCompany } from "../utilities/Game"
+import { getClassState, getCompanyType, getTurn, isCompanyOperational, produceForCompany } from "../utilities/Game"
 import { NUM_POLITICAL_PRESSURE_PER_VOTE, PLAYER_CLASSES } from "../utilities/Constants"
 
 // The internals will be replaced with complicated network state management stuff later
@@ -56,9 +56,16 @@ export function useGameState(originalGameState: GameState, options?: {sideEffect
 					// Production
 					gameState.current.classes.forEach(classState => {
 						classState.companies.forEach(company => {
+							const maxWageLevel = getCompanyType(company).wageLevels.length - 1
+							const struck = company.onStrike && company.wageLevel < maxWageLevel
 							if (isCompanyOperational(company)) {
-								produceForCompany(gameState.current, classState, company)
+								if (struck) {
+									getClassState(gameState.current, "Working Class").consumableGoods.Influence += 1
+								} else {
+									produceForCompany(gameState.current, classState, company)
+								}
 							}
+							company.onStrike = false
 							company.workers.forEach(worker => worker.committed = false)
 						})
 					})

--- a/packages/webapp/src/utilities/Constants.ts
+++ b/packages/webapp/src/utilities/Constants.ts
@@ -1,6 +1,6 @@
 import { range, take } from "lodash"
 import { Action, CapitalistClassState, CompanyType, ExportDeals, GameState, ImportDeal, Industry, PlayerClass, PlayerClassName, Policy, StateClassState } from "./Types"
-import { changeCredibility, changeMoney, changeStoredGoods, getClassState, getImportDealPrice, getImportDealTariff, getImportPrice, getIndustry } from "./Game"
+import { changeCredibility, changeMoney, changeStoredGoods, getClassState, getImportDealPrice, getImportDealTariff, getImportPrice, getIndustry, getStrikeTargets, isStrikeTarget } from "./Game"
 import { isAre, s } from "./Misc"
 
 export const COMPANY_SIZE_PX = 220
@@ -13,6 +13,7 @@ export const BACKGROUND_SHADE_T0 = "#374247"
 export const BACKGROUND_SHADE_T1 = "#2b3438"
 export const ACCENT_COLOR_SATURATION = 25
 export const ACCENT_COLOR_LIGHTNESS = 45
+export const STRIKE_COLOR = "#b91c1c"
 
 export const MATERIAL_ICON_NAME_MAPPINGS = {
 	"tax-multiplier": "receipt_long",
@@ -315,7 +316,22 @@ export const BASIC_ACTIONS: Array<Action> = [
 	{name: "Lobby", type: "basic", playerClasses: ["Capitalist Class"], description: "Spend $30 from capital to gain 3 <Influence>"},
 	{name: "Buy goods", type: "basic", playerClasses: ["Working Class", "Middle Class"], description: "Buy a single type of good from up to two sellers. The number of goods must be less than or equal to your population."},
 	{name: "Work extra shift", type: "basic", playerClasses: ["Middle Class"], description: "Choose one of your companies with non-committed Middle Class workers. Pay wages and produce."},
-	{name: "Strike", type: "basic", playerClasses: ["Working Class"], description: "Choose 2 companies where your workers work, with no committed workers, and without the maximum wage level. Those companies will not not function if they have not increased to thew maximum wage level by the production phase."},
+	{
+		name: "Strike",
+		type: "basic",
+		playerClasses: ["Working Class"],
+		description: "Choose 2 companies where your workers work, with no committed workers, and without the maximum wage level. Those companies will not not function if they have not increased to thew maximum wage level by the production phase.",
+		isPossible: ({gameState}) => getStrikeTargets(gameState).length > 0,
+		execute: async ({gameState, setText, selectCompany}) => {
+			for (let placed = 0; placed < 2; placed++) {
+				if (getStrikeTargets(gameState).length === 0) break
+				setText(placed === 0 ? "Select a company to strike." : "Select another company to strike, or click Done.")
+				const company = await selectCompany(isStrikeTarget)
+				if (company === undefined) break
+				company.onStrike = true
+			}
+		}
+	},
 	{name: "Demonstrate", type: "basic", playerClasses: ["Working Class"], description: "When played then if the following remains true till the production phase then gain 1 <Influence> and other players lose VP: The number of your unemployed workers is at least 2 more than the number of unoccupied worker slots."},
 	{
 		name: "Apply political pressure",
@@ -379,7 +395,7 @@ export const FREE_ACTIONS: Array<Action> = [
 ]
 
 export const GAME_STATE: GameState = {
-	turnIndex: 18,
+	turnIndex: 16,
 	mainActionCompleted: false,
 	freeActionCompleted: false,
 	policies: {
@@ -466,6 +482,7 @@ export const GAME_STATE: GameState = {
 				{
 					name: "Convenience Store",
 					wageLevel: 0,
+					onStrike: false,
 					workers: [
 						{class: "Middle Class", skill: "Food", committed: false},
 						{class: "Working Class", committed: false}
@@ -504,6 +521,7 @@ export const GAME_STATE: GameState = {
 				{
 					name: "Clinic",
 					wageLevel: 1,
+					onStrike: false,
 					workers: [
 						{class: "Middle Class", committed: true},
 						{class: "Middle Class", skill: "Influence", committed: true}
@@ -512,6 +530,7 @@ export const GAME_STATE: GameState = {
 				{
 					name: "Shopping Mall",
 					wageLevel: 1,
+					onStrike: false,
 					workers: [
 						{class: "Working Class", skill: "Luxury", committed: false},
 						{class: "Working Class", skill: "Healthcare", committed: false},
@@ -548,6 +567,7 @@ export const GAME_STATE: GameState = {
 				{
 					name: "University",
 					wageLevel: 1,
+					onStrike: false,
 					workers: [
 						{class: "Middle Class", skill: "Education", committed: false},
 						{class: "Middle Class", committed: false},
@@ -557,6 +577,7 @@ export const GAME_STATE: GameState = {
 				{
 					name: "NPR",
 					wageLevel: 0,
+					onStrike: false,
 					workers: []
 				}
 			],

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -57,6 +57,18 @@ export function isCompanyOperational(company: Company) {
 	return company.workers.length >= companyType.workerSlots.filter(slot => slot.productionBonus === undefined).length
 }
 
+export function isStrikeTarget(company: Company): boolean {
+	const maxWageLevel = getCompanyType(company).wageLevels.length - 1
+	return !company.onStrike
+		&& company.workers.some(worker => worker.class === "Working Class")
+		&& !company.workers.some(worker => worker.committed)
+		&& company.wageLevel < maxWageLevel
+}
+
+export function getStrikeTargets(gameState: GameState): Array<Company> {
+	return gameState.classes.flatMap(classState => classState.companies).filter(isStrikeTarget)
+}
+
 export function getTurn(gameState: GameState) {
 	return {
 		roundNumber: Math.floor(gameState.turnIndex / (4 * 5)) + 1,

--- a/packages/webapp/src/utilities/Game.ts
+++ b/packages/webapp/src/utilities/Game.ts
@@ -85,11 +85,22 @@ export function changeMoney(classState: ClassState, delta: number) {
 
 		while (remainingDue > 0) {
 			classState.loans += 1
-			classState.cash += 50
 
-			const loanPaid = Math.min(50, remainingDue)
-			classState.cash -= loanPaid
-			remainingDue -= loanPaid
+			if (classState.className === "Capitalist Class") {
+				const capitalistState = classState as CapitalistClassState
+
+				capitalistState.capital += 50
+
+				const loanPaid = Math.min(50, remainingDue)
+				capitalistState.capital -= loanPaid
+				remainingDue -= loanPaid
+			} else {
+				classState.cash += 50
+
+				const loanPaid = Math.min(50, remainingDue)
+				classState.cash -= loanPaid
+				remainingDue -= loanPaid
+			}
 		}
 	}
 }

--- a/packages/webapp/src/utilities/Types.ts
+++ b/packages/webapp/src/utilities/Types.ts
@@ -58,7 +58,8 @@ export type Worker = {
 export type Company = {
 	name: string,
 	wageLevel: number,
-	workers: Array<Worker>
+	workers: Array<Worker>,
+	onStrike: boolean
 }
 
 type CommonClassState = {
@@ -192,7 +193,8 @@ export type Action = {
 		setText: (text: string) => void,
 		selectPolicyPosition: (predicate: (policyPosition: PolicyPosition) => boolean) => Promise<PolicyPosition>,
 		selectImportDeal: (predicate: (importDeal: ImportDeal) => boolean) => Promise<ImportDeal>
-		selectPreferredImportDealDestination: () => Promise<PreferredImportDealDestination>
+		selectPreferredImportDealDestination: () => Promise<PreferredImportDealDestination>,
+		selectCompany: (predicate: (company: Company) => boolean) => Promise<Company | undefined>
 	}) => Promise<void>
 }
 
@@ -203,6 +205,8 @@ export type ActionExecution = {
 	importDealPredicate?: (importDeal: ImportDeal) => boolean,
 	importDealCallback?: (preference: ImportDeal) => void,
 	preferredImportDealDestinationCallback?: (preference: PreferredImportDealDestination) => void,
+	companyPredicate?: (company: Company) => boolean,
+	companyCallback?: (company: Company | undefined) => void,
 	text?: string
 }
 

--- a/packages/webapp/tst/utilities/Game.test.ts
+++ b/packages/webapp/tst/utilities/Game.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test } from "vitest"
 import {
 	capitalToWealthTier, changeCredibility, changeMoney, changeStoredGoods, getClassState, getCompanyType,
 	getImportDealPrice, getImportDealTariff, getImportPrice, getImportTariff, getIndustry, getMaxStorage,
-	getPlayerClass, getTurn, isCompanyOperational, produceForCompany
+	getPlayerClass, getTurn, isCompanyOperational, isStrikeTarget, produceForCompany
 } from "../../src/utilities/Game"
 import { WEALTH_TIER_THRESHOLDS } from "../../src/utilities/Constants"
 import { Company, ImportDeal, StateClassState } from "../../src/utilities/Types"
@@ -23,7 +23,7 @@ describe("getIndustry", () => {
 
 describe("getCompanyType", () => {
 	test("returns the company type matching the company's name", () => {
-		const companyType = getCompanyType({name: "Clinic", wageLevel: 0, workers: []})
+		const companyType = getCompanyType({name: "Clinic", wageLevel: 0, workers: [], onStrike: false})
 		expect(companyType.name).toBe("Clinic")
 		expect(companyType.industry).toBe("Healthcare")
 		expect(companyType.production).toBe(6)
@@ -127,7 +127,8 @@ describe("isCompanyOperational", () => {
 		const company: Company = {
 			name: "Clinic",
 			wageLevel: 0,
-			workers: [{class: "Working Class", committed: true}, {class: "Working Class", committed: true}]
+			workers: [{class: "Working Class", committed: true}, {class: "Working Class", committed: true}],
+			onStrike: false
 		}
 		expect(isCompanyOperational(company)).toBe(true)
 	})
@@ -136,7 +137,8 @@ describe("isCompanyOperational", () => {
 		const company: Company = {
 			name: "Clinic",
 			wageLevel: 0,
-			workers: [{class: "Working Class", committed: true}]
+			workers: [{class: "Working Class", committed: true}],
+			onStrike: false
 		}
 		expect(isCompanyOperational(company)).toBe(false)
 	})
@@ -276,7 +278,8 @@ describe("produceForCompany", () => {
 		capitalist.companies = [{
 			name: "Clinic", // Healthcare, production 6, wageLevels [10, 20, 30]
 			wageLevel: 0,
-			workers: [{class: "Working Class", committed: true}, {class: "Working Class", committed: true}]
+			workers: [{class: "Working Class", committed: true}, {class: "Working Class", committed: true}],
+			onStrike: false
 		}]
 		const gameState = makeGameState({
 			classes: [workingClass, makeMiddleClassState(), capitalist, makeStateClassState()]
@@ -294,7 +297,7 @@ describe("produceForCompany", () => {
 		const workingClass = makeWorkingClassState()
 		// No workers in the wage-bearing slots, so production happens with no wages
 		// to pay, isolating the consumable-goods branch.
-		workingClass.companies = [{name: "Clinic", wageLevel: 0, workers: []}]
+		workingClass.companies = [{name: "Clinic", wageLevel: 0, workers: [], onStrike: false}]
 		const gameState = makeGameState({
 			classes: [workingClass, makeMiddleClassState(), makeCapitalistClassState(), makeStateClassState()]
 		})
@@ -302,5 +305,39 @@ describe("produceForCompany", () => {
 		produceForCompany(gameState, workingClass, workingClass.companies[0])
 
 		expect(workingClass.consumableGoods.Healthcare).toBe(6)
+	})
+})
+
+describe("isStrikeTarget", () => {
+	// "Shopping Mall" has a Working-Class worker slot and wage levels [15, 20, 25],
+	// so its maximum wage level is 2.
+	function shoppingMall(overrides: Partial<Company> = {}): Company {
+		return {
+			name: "Shopping Mall",
+			wageLevel: 0,
+			workers: [{class: "Working Class", committed: false}],
+			onStrike: false,
+			...overrides
+		}
+	}
+
+	test("is a target when the Working Class has uncommitted workers and wages are below max", () => {
+		expect(isStrikeTarget(shoppingMall())).toBe(true)
+	})
+
+	test("is not a target when already at the maximum wage level", () => {
+		expect(isStrikeTarget(shoppingMall({wageLevel: 2}))).toBe(false)
+	})
+
+	test("is not a target when any worker is committed", () => {
+		expect(isStrikeTarget(shoppingMall({workers: [{class: "Working Class", committed: true}]}))).toBe(false)
+	})
+
+	test("is not a target without a Working Class worker", () => {
+		expect(isStrikeTarget(shoppingMall({workers: [{class: "Middle Class", committed: false}]}))).toBe(false)
+	})
+
+	test("is not a target when already on strike", () => {
+		expect(isStrikeTarget(shoppingMall({onStrike: true}))).toBe(false)
 	})
 })

--- a/packages/webapp/tst/utilities/Game.test.ts
+++ b/packages/webapp/tst/utilities/Game.test.ts
@@ -200,6 +200,17 @@ describe("changeMoney", () => {
 		expect(classState.capital).toBe(80)
 		expect(classState.loans).toBe(0)
 	})
+	
+	test("a capitalist taking a loan adds the loan money to capital, not cash", () => {
+		const classState = makeCapitalistClassState({cash: 10, capital: 20})
+		// Owes 100. Pays 10 from cash and 20 from capital, then borrows 2 loans
+		// ($50 each) to cover the remaining 70. The $30 of unspent loan money lands
+		// in capital, and cash stays at 0.
+		changeMoney(classState, -100)
+		expect(classState.loans).toBe(2)
+		expect(classState.cash).toBe(0)
+		expect(classState.capital).toBe(30)
+	})
 })
 
 describe("changeCredibility", () => {


### PR DESCRIPTION
Changes include:
* Fix capitalist loan money being sent to cash. It should go to capital
* Add onStrike to Company and represent it in the CompanyCard as a red box in the top left with a hand on it
* Make ActionExecution able to select a company, including wiring it all the way into the PlayerClassPanel and making the companies showing in there be selectable
* Add selectCompany function to Action based on the new ActionExecution functionality
* Implement the strike Action by using selectCompany
* Update production to lift the strike at the end. When that happens it only produces if the wages had been put to the max
* Move the GAME_STATE's turnIndex to be for the working class to make it easier to test this change. I have no concerns with moving it now

See it at https://democracymanifest.paulapps.dev/

Solves https://github.com/paulbarmstrong/democracy-manifest/issues/17, https://github.com/paulbarmstrong/democracy-manifest/issues/24